### PR TITLE
Fix 'sample' flow and add 'node ' to npm start script

### DIFF
--- a/flows/tiddlywiki.json
+++ b/flows/tiddlywiki.json
@@ -1947,7 +1947,7 @@
         "file": "",
         "updtostory": true,
         "tostory": "true",
-        "template": "title: Topic '{%topic%}'\ntopicbtn: <$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\ntopic: {%topic%}\n\n<$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\n\n<$macrocall $name=\"copy-to-clipboard\" src={{!!topicbtn}}/>\n\n```\n<$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\n```\n\n---\n\nTopic: <$edit-text field=topic class=poc2go-edit-text />\n\n<$set name=topic value={{!!topic}}>\n<$button actions=\"<<node-red 'sample $(topic)$'>>\"> Generate Sample </$button>\n</$set>\n",
+        "template": "title: Topic '{%topic%}'\nmustache: yes\ntopicbtn: <$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\ntopic: {%topic%}\n\n<$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\n\n<$macrocall $name=\"copy-to-clipboard\" src={{!!topicbtn}}/>\n\n```\n<$button actions=\"<<node-red '{%topic%}'>>\"> {%topic%} </$button>\n```\n\n---\n\nTopic: <$edit-text field=topic class=poc2go-edit-text />\n\n<$set name=topic value={{!!topic}}>\n<$button actions=\"<<node-red 'sample $(topic)$'>>\"> Generate Sample </$button>\n</$set>\n",
         "clear": false,
         "editorIsOpen": true,
         "settingsIsOpen": false,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node-red-contrib-users": "^0.1.10"
   },
   "scripts": {
-    "start": "./node_modules/node-red/red.js -s ./settings.js",
+    "start": "node ./node_modules/node-red/red.js -s ./settings.js",
     "syncserver": "node ./syncserver",
     "mon": "nodemon --ext js,html,json --watch src/nodes /usr/lib/node_modules/node-red/red.js --settings ./settings.js"
   },

--- a/public/app/welcome/tiddlers/$__StoryList_1.tid
+++ b/public/app/welcome/tiddlers/$__StoryList_1.tid
@@ -1,3 +1,2 @@
 list: [[TW5-Node-RED beta]]
 title: $:/StoryList
-type: text/vnd.tiddlywiki

--- a/public/app/welcome/tiddlers/$__poc2go_toc_selectedTiddler.tid
+++ b/public/app/welcome/tiddlers/$__poc2go_toc_selectedTiddler.tid
@@ -1,5 +1,5 @@
 created: 20231126155823356
-modified: 20240306145836361
+modified: 20240307132427578
 title: $:/poc2go/toc/selectedTiddler
 type: text/vnd.tiddlywiki
 

--- a/public/app/welcome/tiddlers/Mustache.tid
+++ b/public/app/welcome/tiddlers/Mustache.tid
@@ -1,6 +1,6 @@
 created: 20231202195211285
 fetched: 20231203150318127
-modified: 20240117014412777
+modified: 20240307132235311
 tags: ·node-red· [[How it works]]
 title: Mustache
 type: text/vnd.tiddlywiki
@@ -38,8 +38,12 @@ return msg;
 
 The 'Generate sample' [[Set network]] node has a tiddler in the editor which substitutes {%topic%} (msg.topic) which now only contains the parameter - in this case 'hello'. (Double click the 'Generate sample' node to see the complete markup).
 
+
+> @@color:pink; Note: the field `mustache: yes` is required for TW5-Node-RED to process the tiddler using the Mustache template engine to perform the substitutions.@@
+
 ```
 title: Topic '{%topic%}'
+mustache: yes
 topicbtn: <$button actions="<<node-red '{%topic%}'>>"> {%topic%} </$button>
 topic: {%topic%}
 


### PR DESCRIPTION
The sample flow did not have the field 'mustache: yes' thus the text substitution was not being done.

'npm start'  script required 'node ' at the beginning to work for all platforms
